### PR TITLE
Add maven plugin plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,19 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.2</version>
+        <executions>
+          <execution>
+            <id>generated-helpmojo</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,21 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9</version>
+        <configuration>
+          <!-- avoiding javadoc warnings caused by Mojo annotations -->
+          <tagletArtifacts>
+            <tagletArtifact>
+              <groupId>org.apache.maven.plugin-tools</groupId>
+              <artifactId>maven-plugin-tools-javadoc</artifactId>
+              <version>3.2</version>
+            </tagletArtifact>
+          </tagletArtifacts>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/java/jp/co/worksap/jax_rs/GenerateMojo.java
+++ b/src/main/java/jp/co/worksap/jax_rs/GenerateMojo.java
@@ -21,36 +21,49 @@ import org.apache.maven.project.MavenProject;
 import com.google.common.collect.Lists;
 
 /**
+ * <p>Generate JavaScript code which connect to JAX-RS Server.
+ * It uses Java controller to generate JavaScript code, and put them into specified directory.
+ *
+ * <p>See also: https://github.com/WorksApplications/js-generator-for-jax-rs
+ *
  * @goal generate
  * @phase process-classes
  * @author Kengo TODA
  */
 public final class GenerateMojo extends AbstractMojo {
     /**
-     * Package which target controllers belong.
+     * <p>Package which target controllers belong.
      *
      * @parameter
      * @required
      */
     protected String packageName;
     /**
-     * Place where generated scripts will be stored.
+     * <p>Directory where generated scripts will be stored.
      *
      * @parameter
      * @required
      */
     protected File outputDirectory;
     /**
-     * @parameter expression="${project}"
+     * @parameter property="project"
      * @required
      */
     private MavenProject project;
     /**
+     * <p>Name of meta tag to get context path.
+     * If your page has a meta tag like below, this parameter should be &quot;application-data&quot;.
+     *
+     * <p>{@code <meta name="application-data" data-context-path="context-path">}
      * @parameter default-value="application-data"
      * @required
      */
     private String metaTagName;
     /**
+     * <p>Name of data attribute to get context path.
+     * If your page has a meta tag like below, this parameter should be &quot;context-path&quot;.
+     *
+     * <p>{@code <meta name="app-data" data-context-path="context-path">}
      * @parameter default-value="context-path"
      * @required
      */


### PR DESCRIPTION
Added `help` goal to show usage. Examples are here:

``` zsh
% mvn jp.co.worksap.jax_rs:js-generator-for-jax-rs:1.0.1-SNAPSHOT:help
[INFO] --- js-generator-for-jax-rs:1.0.1-SNAPSHOT:help (default-cli) @ js-generator-for-jax-rs ---
[INFO] a Maven plugin to generate JavaScript for JAX-RS 1.0.1-SNAPSHOT


This plugin has 2 goals:

js-generator-for-jax-rs:generate
  Generate JavaScript code which connect to JAX-RS Server. It uses Java
  controller to generate JavaScript code, and put them into specified directory.

  See also: https://github.com/WorksApplications/js-generator-for-jax-rs

js-generator-for-jax-rs:help
  Display help information on js-generator-for-jax-rs.
  Call mvn js-generator-for-jax-rs:help -Ddetail=true -Dgoal=<goal-name> to
  display parameter details.
```

``` zsh
 % mvn jp.co.worksap.jax_rs:js-generator-for-jax-rs:1.0.1-SNAPSHOT:help -Ddetail -Dgoal=generate
[INFO] --- js-generator-for-jax-rs:1.0.1-SNAPSHOT:help (default-cli) @ js-generator-for-jax-rs ---
[INFO] a Maven plugin to generate JavaScript for JAX-RS 1.0.1-SNAPSHOT


js-generator-for-jax-rs:generate
  Generate JavaScript code which connect to JAX-RS Server. It uses Java
  controller to generate JavaScript code, and put them into specified directory.

  See also: https://github.com/WorksApplications/js-generator-for-jax-rs

  Available parameters:

    dataNameToGetContextPath
      Name of data attribute to get context path. If your page has a meta tag
      like below, this parameter should be 'context-path'.

      <meta name='app-data' data-context-path='context-path'>
      Required: Yes

    metaTagName
      Name of meta tag to get context path. If your page has a meta tag like
      below, this parameter should be 'application-data'.

      <meta name='application-data' data-context-path='context-path'>
      Required: Yes

    outputDirectory
      Directory where generated scripts will be stored.
      Required: Yes

    packageName
      Package which target controllers belong.
      Required: Yes

    project

      Required: Yes
```
